### PR TITLE
style: shorten apache header

### DIFF
--- a/bavard.go
+++ b/bavard.go
@@ -224,23 +224,12 @@ func aggregate(values []string) string {
 func Apache2Header(copyrightHolder string, year int) string {
 	apache2 := `
 	// Copyright %d %s
-	//
-	// Licensed under the Apache License, Version 2.0 (the "License");
-	// you may not use this file except in compliance with the License.
-	// You may obtain a copy of the License at
-	//
-	//     http://www.apache.org/licenses/LICENSE-2.0
-	//
-	// Unless required by applicable law or agreed to in writing, software
-	// distributed under the License is distributed on an "AS IS" BASIS,
-	// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	// See the License for the specific language governing permissions and
-	// limitations under the License.
+	// Licensed under the Apache License, Version 2.0. See the LICENSE file for details.
 	`
 	return fmt.Sprintf(apache2, year, copyrightHolder)
 }
 
-// Apache2 returns a bavard option to be used in Generate writing an apache2 licence header in the generated file
+// Apache2 returns a bavard option to be used in Generate writing an apache2 license header in the generated file
 func Apache2(copyrightHolder string, year int) func(*Bavard) error {
 	return func(b *Bavard) error {
 		b.license = Apache2Header(copyrightHolder, year)


### PR DESCRIPTION
Replace the verbose generated Apache 2.0 header by a single line. Sufficient according to ChatGPT and common practice in other Apache 2 licensed projects.