### PR TITLE
feat: filter build by env variable

### DIFF
--- a/bavard.go
+++ b/bavard.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	EnvFilter = "BAVARD" // environment variable to filter generation
+	EnvFilter = "BAVARD_FILTER" // environment variable to filter generation
 )
 
 // Bavard root object to configure the code generation from text/template

--- a/bavard.go
+++ b/bavard.go
@@ -64,7 +64,7 @@ type Entry struct {
 	BuildTag  string
 }
 
-func shouldGenerate(output string) bool {
+func ShouldGenerate(output string) bool {
 	envFilter := os.Getenv(EnvFilter)
 	if envFilter == "" {
 		return true
@@ -76,7 +76,7 @@ func shouldGenerate(output string) bool {
 // GenerateFromString will concatenate templates and create output file from executing the resulting text/template
 // see other package functions to add options (package name, licensing, build tags, ...)
 func GenerateFromString(output string, templates []string, data interface{}, options ...func(*Bavard) error) error {
-	if !shouldGenerate(output) {
+	if !ShouldGenerate(output) {
 		return nil // skip generation
 	}
 	var b Bavard
@@ -109,7 +109,7 @@ func GenerateFromString(output string, templates []string, data interface{}, opt
 // GenerateFromFiles will concatenate templates and create output file from executing the resulting text/template
 // see other package functions to add options (package name, licensing, build tags, ...)
 func GenerateFromFiles(output string, templateF []string, data interface{}, options ...func(*Bavard) error) error {
-	if !shouldGenerate(output) {
+	if !ShouldGenerate(output) {
 		return nil // skip generation
 	}
 	var b Bavard

--- a/bavard.go
+++ b/bavard.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	envVar = "BAVARD" // environment variable to filter generation
+	EnvFilter = "BAVARD" // environment variable to filter generation
 )
 
 // Bavard root object to configure the code generation from text/template
@@ -65,7 +65,7 @@ type Entry struct {
 }
 
 func shouldGenerate(output string) bool {
-	envFilter := os.Getenv(envVar)
+	envFilter := os.Getenv(EnvFilter)
 	if envFilter == "" {
 		return true
 	}
@@ -77,7 +77,6 @@ func shouldGenerate(output string) bool {
 // see other package functions to add options (package name, licensing, build tags, ...)
 func GenerateFromString(output string, templates []string, data interface{}, options ...func(*Bavard) error) error {
 	if !shouldGenerate(output) {
-		fmt.Printf("skipping generation of %s\n", output)
 		return nil // skip generation
 	}
 	var b Bavard
@@ -111,7 +110,6 @@ func GenerateFromString(output string, templates []string, data interface{}, opt
 // see other package functions to add options (package name, licensing, build tags, ...)
 func GenerateFromFiles(output string, templateF []string, data interface{}, options ...func(*Bavard) error) error {
 	if !shouldGenerate(output) {
-		fmt.Printf("skipping generation of %s\n", output)
 		return nil // skip generation
 	}
 	var b Bavard

--- a/bavard.go
+++ b/bavard.go
@@ -22,6 +22,10 @@ import (
 	"rsc.io/tmplfunc"
 )
 
+const (
+	envVar = "BAVARD" // environment variable to filter generation
+)
+
 // Bavard root object to configure the code generation from text/template
 type Bavard struct {
 	verbose     bool
@@ -60,9 +64,22 @@ type Entry struct {
 	BuildTag  string
 }
 
+func shouldGenerate(output string) bool {
+	envFilter := os.Getenv(envVar)
+	if envFilter == "" {
+		return true
+	}
+
+	return strings.Contains(output, envFilter)
+}
+
 // GenerateFromString will concatenate templates and create output file from executing the resulting text/template
 // see other package functions to add options (package name, licensing, build tags, ...)
 func GenerateFromString(output string, templates []string, data interface{}, options ...func(*Bavard) error) error {
+	if !shouldGenerate(output) {
+		fmt.Printf("skipping generation of %s\n", output)
+		return nil // skip generation
+	}
 	var b Bavard
 
 	var buf bytes.Buffer
@@ -93,6 +110,10 @@ func GenerateFromString(output string, templates []string, data interface{}, opt
 // GenerateFromFiles will concatenate templates and create output file from executing the resulting text/template
 // see other package functions to add options (package name, licensing, build tags, ...)
 func GenerateFromFiles(output string, templateF []string, data interface{}, options ...func(*Bavard) error) error {
+	if !shouldGenerate(output) {
+		fmt.Printf("skipping generation of %s\n", output)
+		return nil // skip generation
+	}
 	var b Bavard
 	var buf bytes.Buffer
 


### PR DESCRIPTION
Upstream call doing 
```
BAVARD=koalabear go generate ./... 
```

will generate only files containing koalabear in output path. We could push it a bit with a full regex.